### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/routes/itemRoutes.js
+++ b/routes/itemRoutes.js
@@ -1,9 +1,18 @@
 // routes/itemRoutes.js
 const express = require('express');
+const RateLimit = require('express-rate-limit');
 const router = express.Router();
 const itemController = require('../controllers/itemController');
 const csrf = require('csurf');
 const csrfProtection = csrf({ cookie: true });
+
+
+// Rate limiter for update-ajax requests: max 10 requests per 15 minutes per IP
+const updateAjaxLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // limit each IP to 10 requests per windowMs
+  message: 'Too many update requests from this IP, please try again later.',
+});
 
 router.get('/', csrfProtection, (req, res) => {
     itemController.getAllItems(req, res, req.csrfToken());
@@ -22,7 +31,7 @@ router.get('/items/edit/:id', csrfProtection, (req, res) => {
 router.post('/items/delete/:id', csrfProtection, itemController.deleteItemAjax);
 
 // Nueva ruta para actualizar un item sin recargar la página
-router.post('/items/update-ajax/:id', csrfProtection, itemController.updateItemAjax);
+router.post('/items/update-ajax/:id', csrfProtection, updateAjaxLimiter, itemController.updateItemAjax);
 
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/mi-super-app-ssr/security/code-scanning/6](https://github.com/santiagourdaneta/mi-super-app-ssr/security/code-scanning/6)

To fix this issue, add a rate-limiting middleware to POST requests that update items. The recommended approach is to use the well-known `express-rate-limit` library. Middleware should be defined (with sensible defaults, e.g. 100 requests per 15 minutes per IP, or stricter for sensitive operations) and applied directly to the `/items/update-ajax/:id` route. Only the code you’ve been shown can be edited, so this logic must be added within `routes/itemRoutes.js`. You need to import `express-rate-limit`, configure a limiter, and insert it into the desired route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
