### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/routes/itemRoutes.js
+++ b/routes/itemRoutes.js
@@ -28,7 +28,7 @@ router.get('/items/edit/:id', csrfProtection, (req, res) => {
     itemController.getEditItem(req, res, req.csrfToken());
 });
 
-router.post('/items/delete/:id', csrfProtection, itemController.deleteItemAjax);
+router.post('/items/delete/:id', csrfProtection, updateAjaxLimiter, itemController.deleteItemAjax);
 
 // Nueva ruta para actualizar un item sin recargar la página
 router.post('/items/update-ajax/:id', csrfProtection, updateAjaxLimiter, itemController.updateItemAjax);


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/mi-super-app-ssr/security/code-scanning/5](https://github.com/santiagourdaneta/mi-super-app-ssr/security/code-scanning/5)

To fix this issue, we should apply rate limiting to the `/items/delete/:id` route in the same way as is done for `/items/update-ajax/:id`. The most robust and maintainable approach is to use a separate rate limiter instance for deletion requests, but given the similarity in sensitivity and traffic expectations with update requests, we can reuse the same limiter instance (`updateAjaxLimiter`) for both. This fix involves modifying line 31 so that the rate limiter middleware sits between `csrfProtection` and the controller, matching the pattern established on line 34. No new imports or dependencies are required. The only change needed is to insert `updateAjaxLimiter` into the array of middleware for the delete route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
