### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/routes/itemRoutes.js
+++ b/routes/itemRoutes.js
@@ -24,7 +24,7 @@ router.get('/items/api/:id', csrfProtection, (req, res) => {
 
 router.post('/items', csrfProtection, itemController.addItemAjax);
 
-router.get('/items/edit/:id', csrfProtection, (req, res) => {
+router.get('/items/edit/:id', csrfProtection, updateAjaxLimiter, (req, res) => {
     itemController.getEditItem(req, res, req.csrfToken());
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/mi-super-app-ssr/security/code-scanning/4](https://github.com/santiagourdaneta/mi-super-app-ssr/security/code-scanning/4)

The best way to fix the problem is to add a rate-limiting middleware to the `/items/edit/:id` route. Since you already have an appropriately configured rate limiter called `updateAjaxLimiter` for AJAX routes (max 10 requests per 15 minutes per IP), it makes sense to use this same middleware for consistency, unless a different threshold is required for GET requests. Specifically, update the `/items/edit/:id` route definition:  
- Add `updateAjaxLimiter` as a middleware before the route handler, i.e., before `(req, res) => ...`.  
- The change only needs to update the argument list for this route definition in `routes/itemRoutes.js`.  
No other code needs to be modified, since the rate limiter is already imported and defined.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
