### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/routes/itemRoutes.js
+++ b/routes/itemRoutes.js
@@ -22,7 +22,7 @@ router.get('/items/api/:id', csrfProtection, (req, res) => {
     itemController.getItemJson(req, res);
 });
 
-router.post('/items', csrfProtection, itemController.addItemAjax);
+router.post('/items', csrfProtection, updateAjaxLimiter, itemController.addItemAjax);
 
 router.get('/items/edit/:id', csrfProtection, updateAjaxLimiter, (req, res) => {
     itemController.getEditItem(req, res, req.csrfToken());


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/mi-super-app-ssr/security/code-scanning/3](https://github.com/santiagourdaneta/mi-super-app-ssr/security/code-scanning/3)

To fix the problem, a rate-limiting middleware should be added to the `/items` POST route (line 25). The rate limiter should be consistent with those used for similar mutating database routes, i.e., use `updateAjaxLimiter`. This involves simply adding `updateAjaxLimiter` to the middleware chain for this route. No further function definitions or new imports are needed, as everything necessary is already present in this file.

Change required:  
- On line 25, update the route registration for POST `/items` to include `updateAjaxLimiter` between the CSRF protection and the controller handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
