### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/routes/itemRoutes.js
+++ b/routes/itemRoutes.js
@@ -14,11 +14,18 @@ const updateAjaxLimiter = RateLimit({
   message: 'Too many update requests from this IP, please try again later.',
 });
 
+// Rate limiter for item JSON API requests: max 100 requests per 15 minutes per IP
+const apiGetLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: 'Too many requests from this IP, please try again later.',
+});
+
 router.get('/', csrfProtection, (req, res) => {
     itemController.getAllItems(req, res, req.csrfToken());
 });
 
-router.get('/items/api/:id', csrfProtection, (req, res) => {
+router.get('/items/api/:id', csrfProtection, apiGetLimiter, (req, res) => {
     itemController.getItemJson(req, res);
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/mi-super-app-ssr/security/code-scanning/2](https://github.com/santiagourdaneta/mi-super-app-ssr/security/code-scanning/2)

To fix the problem, we should add rate limiting middleware to the `/items/api/:id` route. The best approach is to define a new rate limiter suitable for this read-oriented endpoint, or—if reuse is acceptable—use the existing `updateAjaxLimiter`. However, since fetching (GET) may be less sensitive than updating/deleting (POST), we can define a separate limiter for API GET requests, allowing more frequent use (for example, 100 requests per 15 minutes per IP, compared to 10 for mutation).  

**Steps:**
- Define a new limiter before the route definitions, e.g., `apiGetLimiter`, with appropriate rate limits.
- Apply `apiGetLimiter` as middleware to the `/items/api/:id` route on line 21 in addition to `csrfProtection`.

**Required changes:**  
- Create `apiGetLimiter` variable, using `RateLimit` as instantiated on line 11.
- Update the `/items/api/:id` route handler to add the new middleware.
- No new methods or definitions are required beyond that.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
