### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/datadog-synthetics.yml
+++ b/.github/workflows/datadog-synthetics.yml
@@ -12,6 +12,8 @@
 # 2. Start using the action within your workflow
 
 name: Run Datadog Synthetic tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/mi-super-app-ssr/security/code-scanning/7](https://github.com/santiagourdaneta/mi-super-app-ssr/security/code-scanning/7)

To fix this problem, add a permissions block to the workflow to restrict the capabilities of the `GITHUB_TOKEN` that is provisioned for the workflow run. You can set this either at the workflow root level (applies to all jobs unless overridden), or at the job level (applies only to that job). In this workflow, adding it at the root is simplest and preferred for single-job workflows. The safest minimal permissions are usually `contents: read` unless specific steps require more. According to the actions used (`actions/checkout@v4` and DataDog/synthetics-ci-github-action), read access to repository contents is typically sufficient. To implement: insert a `permissions:` block with `contents: read` just after the `name:` field and before the `on:` trigger in `.github/workflows/datadog-synthetics.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
